### PR TITLE
Return first 1000 lines in stead of everything

### DIFF
--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -298,7 +298,8 @@ def extract_from_plain(msg_body):
 
     # don't process too long messages
     if len(lines) > MAX_LINES_COUNT:
-        return stripped_text
+		lines = stripped_text.split('\n', MAX_LINES_COUNT)
+
 
     markers = mark_message_lines(lines)
     lines = process_marked_lines(lines, markers)


### PR DESCRIPTION
If there are more than 1000 lines, the text will not be split. Isn't it better to process only the first 1000 lines, because chances are small that a plain text mail will be longer than 1000 lines? If it reaches MAX_LINES_COUNT you can be almost certain that this is because of a huge mail conversation, not a huge single mail. 