### PR TITLE
Preserve regular blockquotes

### DIFF
--- a/talon/html_quotations.py
+++ b/talon/html_quotations.py
@@ -138,9 +138,10 @@ def cut_by_id(html_message):
 
 
 def cut_blockquote(html_message):
-    ''' Cuts blockquote with wrapping elements. '''
-    quote = html_message.find('.//blockquote')
-    if quote is not None:
+    ''' Cuts the last non-nested blockquote with wrapping elements. '''
+    quote = html_message.xpath('(.//blockquote)[not(ancestor::blockquote)][last()]')
+    if quote:
+        quote = quote[0]
         quote.getparent().remove(quote)
         return True
 

--- a/tests/html_quotations_test.py
+++ b/tests/html_quotations_test.py
@@ -50,6 +50,24 @@ def test_quotation_splitter_outside_blockquote():
         RE_WHITESPACE.sub('', quotations.extract_from_html(msg_body)))
 
 
+def test_regular_blockquote():
+    msg_body = """Reply
+<blockquote>Regular</blockquote>
+
+<div>
+  On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:
+</div>
+
+<blockquote>
+  <div>
+    <blockquote>Nested</blockquote>
+  </div>
+</blockquote>
+"""
+    eq_("<html><body><p>Reply</p><blockquote>Regular</blockquote><div></div></body></html>",
+        RE_WHITESPACE.sub('', quotations.extract_from_html(msg_body)))
+
+
 def test_no_blockquote():
     msg_body = """
 <html>


### PR DESCRIPTION
Some email clients (e.g. Apple Mail) add blockquotes when you indent text or when you copy & paste a part from the original message.
Instead of removing the blockquote element wrapping the original message, talon just removes the first blockquote it finds.

I'm using an xpath expression to only select the last blockquote in the message. It can also handle nested blockquotes.
