### PR TITLE
Fix #85 (exception when stripping gmail quotes)

### DIFF
--- a/talon/html_quotations.py
+++ b/talon/html_quotations.py
@@ -78,7 +78,7 @@ def delete_quotation_tags(html_note, counter, quotation_checkpoints):
 def cut_gmail_quote(html_message):
     ''' Cuts the outermost block element with class gmail_quote. '''
     gmail_quote = html_message.cssselect('div.gmail_quote')
-    if gmail_quote and not RE_FWD.match(gmail_quote[0].text):
+    if gmail_quote and (gmail_quote[0].text is None or not RE_FWD.match(gmail_quote[0].text)):
         gmail_quote[0].getparent().remove(gmail_quote[0])
         return True
 

--- a/tests/html_quotations_test.py
+++ b/tests/html_quotations_test.py
@@ -131,6 +131,17 @@ def test_gmail_quote():
         RE_WHITESPACE.sub('', quotations.extract_from_html(msg_body)))
 
 
+def test_gmail_quote_compact():
+    msg_body = 'Reply' \
+               '<div class="gmail_quote">' \
+               '<div class="gmail_quote">On 11-Apr-2011, at 6:54 PM, Bob &lt;bob@example.com&gt; wrote:' \
+               '<div>Test</div>' \
+               '</div>' \
+               '</div>'
+    eq_("<html><body><p>Reply</p></body></html>",
+        RE_WHITESPACE.sub('', quotations.extract_from_html(msg_body)))
+
+
 def test_gmail_quote_blockquote():
     msg_body = """Message
 <blockquote class="gmail_quote">


### PR DESCRIPTION
lxml will return `None` for an element's `text` property if there's no text content between a parent element and it's first child. The `cut_gmail_quote` function was implicitly relying on `gmail_quote[0].text` to be non-`None`, but when it actually is `None`, the regex eval blows up.

This change makes the code resilient to `None` values.