### PR TITLE
Addition of new split_email method for issue:115

### DIFF
--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -696,3 +696,27 @@ def test_standard_replies():
                 "'%(reply)s' != %(stripped)s for %(fn)s" % \
                 {'reply': reply_text, 'stripped': stripped_text,
                  'fn': filename}
+
+
+def test_split_email():
+    msg = """From: Mr. X
+Date: 24 February 2016
+To: Mr. Y
+Subject: Hi
+Attachments: none
+Goodbye.
+From: Mr. Y
+To: Mr. X
+Date: 24 February 2016
+Subject: Hi
+Attachments: none
+
+Hello.
+
+-- Original Message --
+On 24th February 2016 at 09.32am Conal Wrote:
+Hey!
+"""
+    expected_markers = "stttttsttttetestt"
+    markers = quotations.split_emails(msg)
+    eq_(markers, expected_markers)


### PR DESCRIPTION
Split_email method introduced, allows external libraries to use Talon to split emails.

Removes split markers in the middle of header blocks. Header blocks contain ": ". 

I.e: the below returns the markers "sttete" not "stsete".

> From: Xxx
> To: Xxx
> Date: Xxx
> Subject: Xxx
> 
> Body text.
> 

