### PR TITLE
Move ml deps into extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ class InstallCommand(install):
         install.finalize_options(self)
         if self.no_ml:
             dist = self.distribution
-            dist.packages=find_packages(exclude=[
+            dist.packages = find_packages(exclude=[
                 'tests',
                 'tests.*',
                 'talon.signature',
@@ -46,18 +46,22 @@ setup(name='talon',
       install_requires=[
           "lxml>=2.3.3",
           "regex>=1",
-          "numpy",
-          "scipy",
-          "scikit-learn==0.16.1", # pickled versions of classifier, else rebuild
           'chardet>=1.0.1',
           'cchardet>=0.3.5',
           'cssselect',
           'six>=1.10.0',
           'html5lib'
-          ],
+      ],
+      extras_require={
+          'ml': [
+              "numpy",
+              "scipy",
+              "scikit-learn==0.16.1",  # pickled versions of classifier, else rebuild
+          ]
+      },
       tests_require=[
           "mock",
           "nose>=1.2.1",
           "coverage"
-          ]
+      ]
       )

--- a/talon/__init__.py
+++ b/talon/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 from talon.quotations import register_xpath_extensions
+from talon import signature
+
 try:
-    from talon import signature
+    from talon.signature.learning import classifier
     ML_ENABLED = True
 except ImportError:
     ML_ENABLED = False

--- a/talon/signature/__init__.py
+++ b/talon/signature/__init__.py
@@ -23,9 +23,12 @@ trained against, don't forget to regenerate:
 from __future__ import absolute_import
 import os
 
-from . import extraction
-from . extraction import extract  #noqa
-from . learning import classifier
+try:
+    from . import extraction
+    from . extraction import extract  #noqa
+    from . learning import classifier
+except ImportError:
+    pass
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,31 @@
+[tox]
+envlist =
+    py27-noml
+    py27-ml
+
+[testenv]
+basepython =
+    python2.7
+setenv =
+    PYTHONUNBUFFERED=yes
+usedevelop = false
+extras =
+    py27-ml: ml
+deps =
+    py27-ml: numpy
+    py27-ml: scipy
+    py27-ml: scikit-learn==0.16.1
+    mock
+    nose>=1.2.1
+    coverage
+    lxml>=2.3.3
+    regex>=1
+    chardet>=1.0.1
+    cchardet>=0.3.5
+    cssselect
+    six>=1.10.0
+    html5lib
+changedir = {toxworkdir}/{envname}
+commands =
+    py27-noml: nosetests -w {toxinidir} --ignore-files="extraction_test\.py" --ignore-files="dataset_test\.py"
+    py27-ml: nosetests -w {toxinidir}


### PR DESCRIPTION
A lot of people would like to use talon without ml and it's possible to move the ml deps into extras and install it with `pip install talon[ml]` while `pip install talon` will install light version without ml.
I've implemented such setup and added tox which tests both versions.
This is a breaking change so I'm interested in would you accept such change if I finish all required things for the pr?