### PR TITLE
loosen the encoding requirement for detect_encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class InstallCommand(install):
 
 
 setup(name='talon',
-      version='1.3.5',
+      version='1.3.6',
       description=("Mailgun library "
                    "to extract message quotations and signatures."),
       long_description=open("README.rst").read(),

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -29,7 +29,9 @@ def test_unicode():
 
 def test_detect_encoding():
     eq_ ('ascii', u.detect_encoding(b'qwe').lower())
-    eq_ ('iso-8859-2', u.detect_encoding(u'Versi\xf3n'.encode('iso-8859-2')).lower())
+    ok_ (u.detect_encoding(
+        u'Versi\xf3n'.encode('iso-8859-2')).lower() in [
+            'iso-8859-1', 'iso-8859-2'])
     eq_ ('utf-8', u.detect_encoding(u'привет'.encode('utf8')).lower())
     # fallback to utf-8
     with patch.object(u.chardet, 'detect') as detect:


### PR DESCRIPTION
Though we specifically encode a string with ``iso-8859-2`` some versions of chardet detect it as ``iso-8859-1``. Tests with encodings can be tricky - in some cases several encodings are possible or encoding / decoding library gives its best guess based on some portion of the encoded text (like cchardet).

There is not much we can do about this. We can construct a text that can be decoded only one possible way but it's time-consuming and not reliable. We can remove flaky tests. We can loosen encoding requirements one way or the other.

For now we've chosen to compare decoding result with several possible encodings.