### PR TITLE
Added Outlook 2013 rules

### DIFF
--- a/talon/html_quotations.py
+++ b/talon/html_quotations.py
@@ -94,6 +94,12 @@ def cut_microsoft_quote(html_message):
         #outlook 2007, 2010 (american)
         "//div[@style='border:none;border-top:solid #B5C4DF 1.0pt;"
         "padding:3.0pt 0in 0in 0in']|"
+        #outlook 2013 (international)
+        "//div[@style='border:none;border-top:solid #E1E1E1 1.0pt;"
+        "padding:3.0pt 0cm 0cm 0cm']|"
+        #outlook 2013 (american)
+        "//div[@style='border:none;border-top:solid #E1E1E1 1.0pt;"
+        "padding:3.0pt 0in 0in 0in']|"
         #windows mail
         "//div[@style='padding-top: 5px; "
         "border-top-color: rgb(229, 229, 229); "


### PR DESCRIPTION
Only the border color changes (compared to Outlook 2007, 2010) from `#B5C4DF` to `#E1E1E1`.