### PR TITLE
android_wrote regex incorrectly matching

### DIFF
--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -147,7 +147,7 @@ RE_FROM_COLON_OR_DATE_COLON = re.compile(u'(_+\r?\n)?[\s]*(:?[*]?{})[\s]?:[*]?.*
 RE_ANDROID_WROTE = re.compile(u'[\s]*[-]+.*({})[ ]*[-]+'.format(
     u'|'.join((
         # English
-        'wrote'
+        'wrote',
     ))), re.I)
 
 # Support polymail.io reply format

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -778,3 +778,16 @@ def test_split_email():
     expected_markers = "stttttsttttetesetesmmmmmmssmmmmmmsmmmmmmmm"
     markers = quotations.split_emails(msg)
     eq_(markers, expected_markers)
+
+
+
+def test_feedback_below_left_unparsed():
+    msg_body = """Please enter your feedback below. Thank you.
+
+------------------------------------- Enter Feedback Below -------------------------------------
+
+The user experience was unparallelled. Please continue production. I'm sending payment to ensure
+that this line is intact."""
+
+    parsed = quotations.extract_from_plain(msg_body)
+    eq_(msg_body, parsed.decode('utf8'))


### PR DESCRIPTION
The RE_ANDROID_WROTE regex incorrectly joins the pipe delimiter with the string "wrote", generating a pattern that will match any of those characters. This will match strings like "below ---". The code appears to be anticipating additional words/languages, so I just moved it to a tuple rather than removing the join.