### PR TITLE
Adding support for swedish text Issue #157

### DIFF
--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -40,9 +40,9 @@ RE_ON_DATE_SMB_WROTE = re.compile(
             'Am',
             # Norwegian
             u'På',
+            # Vietnamese
             # Swedish, Danish
             'Den',
-            # Vietnamese
             u'Vào',
         )),
         # Date and sender separator
@@ -72,10 +72,12 @@ RE_ON_DATE_SMB_WROTE = re.compile(
     ))
 # Special case for languages where text is translated like this: 'on {date} wrote {somebody}:'
 RE_ON_DATE_WROTE_SMB = re.compile(
-    u'(-*[>]?[ ]?({0})[ ].*(.*\n){{0,2}}.*({1})[ ]*.*:)'.format(
+    u'(-*[>]?[ ]?({0})[ ].*(.*\n){{0,2}}.*({1})[ ]*.*)'.format(
         # Beginning of the line
         u'|'.join((
         	'Op',
+            # Swedish, Danish
+            u'Den',
         	#German
         	'Am'
         )),
@@ -83,6 +85,8 @@ RE_ON_DATE_WROTE_SMB = re.compile(
         u'|'.join((
             # Dutch
             'schreef','verzond','geschreven',
+            # Norwegian, Swedish
+            u'skrev',
             # German
             'schrieb'
         ))

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -823,3 +823,31 @@ that this line is intact."""
 
     parsed = quotations.extract_from_plain(msg_body)
     eq_(msg_body, parsed.decode('utf8'))
+
+def test_swedish_quotation():
+    msg_body = """Hej Lotta
+
+Ja g=C3=A4rna!
+
+John
+
+Den 26 oktober 2017 23:49 skrev Lotta p=C3=A5 Testcompany <kundtjanst@testc=
+ompany
+>:
+
+> Hej John
+>
+> Vill du ha en gratis tr=C3=B6ja?
+>
+> Med v=C3=A4nlig h=C3=A4lsning, Lotta Testcompany
+>
+"""
+
+    expected_reply = """Hej Lotta
+
+Ja g=C3=A4rna!
+
+John
+    """
+    reply = quotations.extract_from_plain(msg_body)
+    eq_(expected_reply, reply)


### PR DESCRIPTION
Talon wasn't parsing Swedish quoted parts properly.  Found that we were expecting a comma in the date formatting and I made changes to correct this.