### PR TITLE
Add french separator between original text and reply

### DIFF
--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -133,6 +133,8 @@ RE_ORIGINAL_MESSAGE = re.compile(u'[\s]*[-]+[ ]*({})[ ]*[-]+'.format(
     u'|'.join((
         # English
         'Original Message', 'Reply Message',
+        # French
+        'Message original',
         # German
         u'Ursprüngliche Nachricht', 'Antwort Nachricht',
         # Danish

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -194,6 +194,9 @@ def test_english_original_message():
     _check_pattern_original_message('Original Message')
     _check_pattern_original_message('Reply Message')
 
+def test_french_original_message():
+    _check_pattern_original_message('Message original')
+
 def test_german_original_message():
     _check_pattern_original_message(u'Ursprüngliche Nachricht')
     _check_pattern_original_message('Antwort Nachricht')


### PR DESCRIPTION
This PR allows the separator like
```
--------- Message original ------------
```

It occurs in some french e-mails.

