### PR TITLE
detect K-9 signatures

### DIFF
--- a/talon/signature/bruteforce.py
+++ b/talon/signature/bruteforce.py
@@ -39,6 +39,8 @@ RE_PHONE_SIGNATURE = re.compile(r'''
                        ^sent[ ]([\S]*[ ])?from[ ]my[ ]BlackBerry.*$
                        |
                        ^Enviado[ ]desde[ ]mi[ ]([\S]+[ ]){0,2}BlackBerry.*$
+                       |
+                       ^[\S ]*?Android[\S ]*?K-9[\S ]*?\.[\S ]*?\.$
                    )
                    .*
                )

--- a/tests/signature/bruteforce_test.py
+++ b/tests/signature/bruteforce_test.py
@@ -42,7 +42,6 @@ Bob Smith'''
     eq_(('Wow. Awesome!', '--\nBob Smith'),
         bruteforce.extract_signature(msg_body))
 
-
 def test_signature_words():
     msg_body = '''Hey!
 
@@ -81,7 +80,6 @@ def test_mailbox_for_iphone_signature():
 Sent from Mailbox for iPhone"""
     eq_(("Blah", "Sent from Mailbox for iPhone"),
         bruteforce.extract_signature(msg_body))
-
 
 def test_line_starts_with_signature_word():
     msg_body = '''Hey man!
@@ -134,6 +132,19 @@ Enviado desde mi oficina mÃ³vil BlackBerryÂ® de Telcel"""
     eq_(('Blah', u'Enviado desde mi oficina mÃ³vil BlackBerryÂ® de Telcel'),
         bruteforce.extract_signature(msg_body))
 
+def test_k9_signature():
+    msg_body = """Heeyyoooo.
+-- 
+Sent from my Android device with K-9 Mail. Please excuse my brevity."""
+    eq_(('Heeyyoooo.', msg_body[len('Heeyyoooo.\n'):]),
+        bruteforce.extract_signature(msg_body))
+
+def test_french_k9_signature():
+    msg_body = """Heeyyoooo.
+-- 
+Envoyé de mon appareil Android avec Courriel K-9 Mail. Veuillez excuser ma brièveté."""
+    eq_(('Heeyyoooo.', msg_body[len('Heeyyoooo.\n'):]),
+        bruteforce.extract_signature(msg_body))
 
 @patch.object(bruteforce, 'get_delimiter', Mock(side_effect=Exception()))
 def test_crash_in_extract_signature():


### PR DESCRIPTION
This PR detects K-9 signatures to separate them from the main message.

The regular expression is generic in order to fit several translations of the signature.

The original signature text is available at https://github.com/k9mail/k-9/blob/581937a7e33f8c1442d0a6225485fb28f8dab1db/app/ui/src/main/res/values/strings.xml#L64