### PR TITLE
scikit-learn: depend on joblib directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,12 @@ class InstallCommand(install):
                 'talon.signature',
                 'talon.signature.*',
             ])
-            for not_required in ['numpy', 'scipy', 'scikit-learn==0.16.1']:
+            for not_required in [
+                'numpy',
+                'scipy',
+                'scikit-learn==0.16.1',
+                'joblib',
+            ]:
                 dist.install_requires.remove(not_required)
 
 
@@ -49,6 +54,7 @@ setup(name='talon',
           "numpy",
           "scipy",
           "scikit-learn==0.16.1", # pickled versions of classifier, else rebuild
+          'joblib',
           'chardet>=1.0.1',
           'cchardet>=0.3.5',
           'cssselect',

--- a/talon/signature/learning/classifier.py
+++ b/talon/signature/learning/classifier.py
@@ -7,8 +7,8 @@ body belongs to the signature.
 
 from __future__ import absolute_import
 
+import joblib
 from numpy import genfromtxt
-from sklearn.externals import joblib
 from sklearn.svm import LinearSVC
 
 


### PR DESCRIPTION
Closes #206 

`scikit-learn` has deprecated accessing `joblib` internals for a while now, and this is a hard error in the release of `scikit-learn==0.23`.

This PR naively imports `joblib` directly, rather than via `sklearn.externals`.