### PR TITLE
 ImportError: cannot import name 'joblib'

### DIFF
--- a/talon/signature/learning/classifier.py
+++ b/talon/signature/learning/classifier.py
@@ -8,7 +8,7 @@ body belongs to the signature.
 from __future__ import absolute_import
 
 from numpy import genfromtxt
-from sklearn.externals import joblib
+import joblib
 from sklearn.svm import LinearSVC
 
 


### PR DESCRIPTION
`    from sklearn.externals import joblib`
This code was written for an older version of scikit-learn.

Now you can directly use
`import joblib`