### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/talon/constants.py
+++ b/talon/constants.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 import regex as re
 
 
-RE_DELIMITER = re.compile('\r?\n')
+RE_DELIMITER = re.compile(r'\r?\n')

--- a/talon/html_quotations.py
+++ b/talon/html_quotations.py
@@ -10,11 +10,11 @@ from talon.utils import cssselect
 
 CHECKPOINT_PREFIX = '#!%!'
 CHECKPOINT_SUFFIX = '!%!#'
-CHECKPOINT_PATTERN = re.compile(CHECKPOINT_PREFIX + '\d+' + CHECKPOINT_SUFFIX)
+CHECKPOINT_PATTERN = re.compile(CHECKPOINT_PREFIX + r'\d+' + CHECKPOINT_SUFFIX)
 
 # HTML quote indicators (tag ids)
 QUOTE_IDS = ['OLK_SRC_BODY_SECTION']
-RE_FWD = re.compile("^[-]+[ ]*Forwarded message[ ]*[-]+$", re.I | re.M)
+RE_FWD = re.compile(r"^[-]+[ ]*Forwarded message[ ]*[-]+$", re.I | re.M)
 
 
 def add_checkpoint(html_note, counter):

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -21,12 +21,12 @@ from talon.utils import (get_delimiter, html_document_fromstring,
 log = logging.getLogger(__name__)
 
 
-RE_FWD = re.compile("^[-]+[ ]*Forwarded message[ ]*[-]+\s*$", re.I | re.M)
+RE_FWD = re.compile(r"^[-]+[ ]*Forwarded message[ ]*[-]+\s*$", re.I | re.M)
 
 RE_ON_DATE_SMB_WROTE = re.compile(
-    u'(-*[>]?[ ]?({0})[ ].*({1})(.*\n){{0,2}}.*({2}):?-*)'.format(
+    r'(-*[>]?[ ]?({0})[ ].*({1})(.*\n){{0,2}}.*({2}):?-*)'.format(
         # Beginning of the line
-        u'|'.join((
+        r'|'.join((
             # English
             'On',
             # French
@@ -47,14 +47,14 @@ RE_ON_DATE_SMB_WROTE = re.compile(
             u'Vào',
         )),
         # Date and sender separator
-        u'|'.join((
+        r'|'.join((
             # most languages separate date and sender address by comma
             ',',
             # polish date and sender address separator
             u'użytkownik'
         )),
         # Ending of the line
-        u'|'.join((
+        r'|'.join((
             # English
             'wrote', 'sent',
             # French
@@ -75,15 +75,15 @@ RE_ON_DATE_SMB_WROTE = re.compile(
     ))
 # Special case for languages where text is translated like this: 'on {date} wrote {somebody}:'
 RE_ON_DATE_WROTE_SMB = re.compile(
-    u'(-*[>]?[ ]?({0})[ ].*(.*\n){{0,2}}.*({1})[ ]*.*:)'.format(
+    r'(-*[>]?[ ]?({0})[ ].*(.*\n){{0,2}}.*({1})[ ]*.*:)'.format(
         # Beginning of the line
-        u'|'.join((
+        r'|'.join((
         	'Op',
         	#German
         	'Am'
         )),
         # Ending of the line
-        u'|'.join((
+        r'|'.join((
             # Dutch
             'schreef','verzond','geschreven',
             # German
@@ -128,8 +128,8 @@ RE_EMPTY_QUOTATION = re.compile(
 
 # ------Original Message------ or ---- Reply Message ----
 # With variations in other languages.
-RE_ORIGINAL_MESSAGE = re.compile(u'[\s]*[-]+[ ]*({})[ ]*[-]+'.format(
-    u'|'.join((
+RE_ORIGINAL_MESSAGE = re.compile(r'[\s]*[-]+[ ]*({})[ ]*[-]+'.format(
+    r'|'.join((
         # English
         'Original Message', 'Reply Message',
         # German
@@ -138,8 +138,8 @@ RE_ORIGINAL_MESSAGE = re.compile(u'[\s]*[-]+[ ]*({})[ ]*[-]+'.format(
         'Oprindelig meddelelse',
     ))), re.I)
 
-RE_FROM_COLON_OR_DATE_COLON = re.compile(u'((_+\r?\n)?[\s]*:?[*]?({})[\s]?:([^\n$]+\n){{1,2}}){{2,}}'.format(
-    u'|'.join((
+RE_FROM_COLON_OR_DATE_COLON = re.compile(r'((_+\r?\n)?[\s]*:?[*]?({})[\s]?:([^\n$]+\n){{1,2}}){{2,}}'.format(
+    r'|'.join((
         # "From" in different languages.
         'From', 'Van', 'De', 'Von', 'Fra', u'Från',
         # "Date" in different languages.
@@ -151,8 +151,8 @@ RE_FROM_COLON_OR_DATE_COLON = re.compile(u'((_+\r?\n)?[\s]*:?[*]?({})[\s]?:([^\n
     ))), re.I | re.M)
 
 # ---- John Smith wrote ----
-RE_ANDROID_WROTE = re.compile(u'[\s]*[-]+.*({})[ ]*[-]+'.format(
-    u'|'.join((
+RE_ANDROID_WROTE = re.compile(r'[\s]*[-]+.*({})[ ]*[-]+'.format(
+    r'|'.join((
         # English
         'wrote',
     ))), re.I)
@@ -163,7 +163,7 @@ RE_ANDROID_WROTE = re.compile(u'[\s]*[-]+.*({})[ ]*[-]+'.format(
 # <
 # mailto:John Smith <johnsmith@gmail.com>
 # > wrote:
-RE_POLYMAIL = re.compile('On.*\s{2}<\smailto:.*\s> wrote:', re.I)
+RE_POLYMAIL = re.compile(r'On.*\s{2}<\smailto:.*\s> wrote:', re.I)
 
 SPLITTER_PATTERNS = [
     RE_ORIGINAL_MESSAGE,
@@ -172,32 +172,32 @@ SPLITTER_PATTERNS = [
     RE_FROM_COLON_OR_DATE_COLON,
     # 02.04.2012 14:20 пользователь "bob@example.com" <
     # bob@xxx.mailgun.org> написал:
-    re.compile("(\d+/\d+/\d+|\d+\.\d+\.\d+).*\s\S+@\S+", re.S),
+    re.compile(r"(\d+/\d+/\d+|\d+\.\d+\.\d+).*\s\S+@\S+", re.S),
     # 2014-10-17 11:28 GMT+03:00 Bob <
     # bob@example.com>:
-    re.compile("\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}\s+GMT.*\s\S+@\S+", re.S),
+    re.compile(r"\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}\s+GMT.*\s\S+@\S+", re.S),
     # Thu, 26 Jun 2014 14:00:51 +0400 Bob <bob@example.com>:
-    re.compile('\S{3,10}, \d\d? \S{3,10} 20\d\d,? \d\d?:\d\d(:\d\d)?'
-               '( \S+){3,6}@\S+:'),
+    re.compile(r'\S{3,10}, \d\d? \S{3,10} 20\d\d,? \d\d?:\d\d(:\d\d)?'
+               r'( \S+){3,6}@\S+:'),
     # Sent from Samsung MobileName <address@example.com> wrote:
-    re.compile('Sent from Samsung.* \S+@\S+> wrote'),
+    re.compile(r'Sent from Samsung.* \S+@\S+> wrote'),
     RE_ANDROID_WROTE,
     RE_POLYMAIL
     ]
 
-RE_LINK = re.compile('<(http://[^>]*)>')
-RE_NORMALIZED_LINK = re.compile('@@(http://[^>@]*)@@')
+RE_LINK = re.compile(r'<(http://[^>]*)>')
+RE_NORMALIZED_LINK = re.compile(r'@@(http://[^>@]*)@@')
 
-RE_PARENTHESIS_LINK = re.compile("\(https?://")
+RE_PARENTHESIS_LINK = re.compile(r"\(https?://")
 
 SPLITTER_MAX_LINES = 6
 MAX_LINES_COUNT = 1000
 
-QUOT_PATTERN = re.compile('^>+ ?')
-NO_QUOT_LINE = re.compile('^[^>].*[\S].*')
+QUOT_PATTERN = re.compile(r'^>+ ?')
+NO_QUOT_LINE = re.compile(r'^[^>].*[\S].*')
 
 # Regular expression to identify if a line is a header.
-RE_HEADER = re.compile(": ")
+RE_HEADER = re.compile(r": ")
 
 
 def extract_from(msg_body, content_type='text/plain'):
@@ -280,17 +280,17 @@ def process_marked_lines(lines, markers, return_flags=[False, -1, -1]):
     """
     markers = ''.join(markers)
     # if there are no splitter there should be no markers
-    if 's' not in markers and not re.search('(me*){3}', markers):
+    if 's' not in markers and not re.search(r'(me*){3}', markers):
         markers = markers.replace('m', 't')
 
-    if re.match('[te]*f', markers):
+    if re.match(r'[te]*f', markers):
         return_flags[:] = [False, -1, -1]
         return lines
 
     # inlined reply
     # use lookbehind assertions to find overlapping entries e.g. for 'mtmtm'
     # both 't' entries should be found
-    for inline_reply in re.finditer('(?<=m)e*(t[te]*)m', markers):
+    for inline_reply in re.finditer(r'(?<=m)e*(t[te]*)m', markers):
         # long links could break sequence of quotation lines but they shouldn't
         # be considered an inline reply
         links = (
@@ -301,7 +301,7 @@ def process_marked_lines(lines, markers, return_flags=[False, -1, -1]):
             return lines
 
     # cut out text lines coming after splitter if there are no markers there
-    quotation = re.search('(se*)+((t|f)+e*)+', markers)
+    quotation = re.search(r'(se*)+((t|f)+e*)+', markers)
     if quotation:
         return_flags[:] = [True, quotation.start(), len(lines)]
         return lines[:quotation.start()]

--- a/talon/signature/learning/dataset.py
+++ b/talon/signature/learning/dataset.py
@@ -78,7 +78,7 @@ def parse_msg_sender(filename, sender_known=True):
                     # and it is ok
                     lines = msg.splitlines()
                     for line in lines:
-                        match = re.match('From:(.*)', line)
+                        match = re.match(r'From:(.*)', line)
                         if match:
                             sender = match.group(1)
                             break
@@ -104,7 +104,7 @@ def build_detection_class(folder, dataset_filename,
             sender, msg = parse_msg_sender(filename, sender_known)
             if sender is None or msg is None:
                 continue
-            msg = re.sub('|'.join(ANNOTATIONS), '', msg)
+            msg = re.sub(r'|'.join(ANNOTATIONS), '', msg)
             X = build_pattern(msg, features(sender))
             X.append(label)
             labeled_pattern = ','.join([str(e) for e in X])

--- a/talon/signature/learning/helpers.py
+++ b/talon/signature/learning/helpers.py
@@ -13,31 +13,31 @@ from talon.signature.constants import SIGNATURE_MAX_LINES
 
 rc = re.compile
 
-RE_EMAIL = rc('\S@\S')
-RE_RELAX_PHONE = rc('(\(? ?[\d]{2,3} ?\)?.{,3}?){2,}')
+RE_EMAIL = rc(r'\S@\S')
+RE_RELAX_PHONE = rc(r'(\(? ?[\d]{2,3} ?\)?.{,3}?){2,}')
 RE_URL = rc(r"""https?://|www\.[\S]+\.[\S]""")
 
 # Taken from:
 # http://www.cs.cmu.edu/~vitor/papers/sigFilePaper_finalversion.pdf
 # Line matches the regular expression "^[\s]*---*[\s]*$".
-RE_SEPARATOR = rc('^[\s]*---*[\s]*$')
+RE_SEPARATOR = rc(r'^[\s]*---*[\s]*$')
 
 # Taken from:
 # http://www.cs.cmu.edu/~vitor/papers/sigFilePaper_finalversion.pdf
 # Line has a sequence of 10 or more special characters.
-RE_SPECIAL_CHARS = rc(('^[\s]*([\*]|#|[\+]|[\^]|-|[\~]|[\&]|[\$]|_|[\!]|'
-                       '[\/]|[\%]|[\:]|[\=]){10,}[\s]*$'))
+RE_SPECIAL_CHARS = rc((r'^[\s]*([\*]|#|[\+]|[\^]|-|[\~]|[\&]|[\$]|_|[\!]|'
+                       r'[\/]|[\%]|[\:]|[\=]){10,}[\s]*$'))
 
-RE_SIGNATURE_WORDS = rc(('(T|t)hank.*,|(B|b)est|(R|r)egards|'
-                         '^sent[ ]{1}from[ ]{1}my[\s,!\w]*$|BR|(S|s)incerely|'
-                         '(C|c)orporation|Group'))
+RE_SIGNATURE_WORDS = rc((r'(T|t)hank.*,|(B|b)est|(R|r)egards|'
+                         r'^sent[ ]{1}from[ ]{1}my[\s,!\w]*$|BR|(S|s)incerely|'
+                         r'(C|c)orporation|Group'))
 
 # Taken from:
 # http://www.cs.cmu.edu/~vitor/papers/sigFilePaper_finalversion.pdf
 # Line contains a pattern like Vitor R. Carvalho or William W. Cohen.
-RE_NAME = rc('[A-Z][a-z]+\s\s?[A-Z][\.]?\s\s?[A-Z][a-z]+')
+RE_NAME = rc(r'[A-Z][a-z]+\s\s?[A-Z][\.]?\s\s?[A-Z][a-z]+')
 
-INVALID_WORD_START = rc('\(|\+|[\d]')
+INVALID_WORD_START = rc(r'\(|\+|[\d]')
 
 BAD_SENDER_NAMES = [
     # known mail domains
@@ -58,9 +58,9 @@ def binary_regex_search(prog):
     and 0 otherwise.
 
     >>> import regex as re
-    >>> binary_regex_search(re.compile("12"))("12")
+    >>> binary_regex_search(re.compile(r"12"))("12")
     1
-    >>> binary_regex_search(re.compile("12"))("34")
+    >>> binary_regex_search(re.compile(r"12"))("34")
     0
     """
     return lambda s: 1 if prog.search(s) else 0
@@ -74,9 +74,9 @@ def binary_regex_match(prog):
     and 0 otherwise.
 
     >>> import regex as re
-    >>> binary_regex_match(re.compile("12"))("12 3")
+    >>> binary_regex_match(re.compile(r"12"))("12 3")
     1
-    >>> binary_regex_match(re.compile("12"))("3 12")
+    >>> binary_regex_match(re.compile(r"12"))("3 12")
     0
     """
     return lambda s: 1 if prog.match(s) else 0
@@ -112,8 +112,8 @@ def contains_sender_names(sender):
     >>> contains_sender_names("<serobnic@mail.ru>")("serobnic")
     1
     """
-    names = '( |$)|'.join(flatten_list([[e, e.capitalize()]
-                                        for e in extract_names(sender)]))
+    names = r'( |$)|'.join(flatten_list([[e, e.capitalize()]
+                                         for e in extract_names(sender)]))
     names = names or sender
     if names != '':
         return binary_regex_search(re.compile(names))
@@ -182,7 +182,7 @@ def punctuation_percent(s):
 
 def capitalized_words_percent(s):
     """Returns capitalized words percent."""
-    words = re.split('\s', s)
+    words = re.split(r'\s', s)
     words = [w for w in words if w.strip()]
     words = [w for w in words if len(w) > 2]    
     capitalized_words_counter = 0

--- a/talon/utils.py
+++ b/talon/utils.py
@@ -132,4 +132,4 @@ _UTF8_DECLARATION = ('<meta http-equiv="Content-Type" content="text/html;'
 _BLOCKTAGS = ['div', 'p', 'ul', 'li', 'h1', 'h2', 'h3']
 _HARDBREAKS = ['br', 'hr', 'tr']
 
-_RE_EXCESSIVE_NEWLINES = re.compile("\n{2,10}")
+_RE_EXCESSIVE_NEWLINES = re.compile(r"\n{2,10}")

--- a/tests/signature/learning/helpers_test.py
+++ b/tests/signature/learning/helpers_test.py
@@ -137,17 +137,17 @@ def test_extract_names():
         '"**Bobby B**" <copymycashsystem@example.com>':
         ['Bobby', 'copymycashsystem'],
         # from crash reports `bad escape`
-        '"M Ali B Azlan \(GHSE/PETH\)" <aliazlan@example.com>':
+        '"M Ali B Azlan (GHSE/PETH)" <aliazlan@example.com>':
         ['Ali', 'Azlan'],
-        ('"Ridthauddin B A Rahim \(DD/PCSB\)"'
+        ('"Ridthauddin B A Rahim (DD/PCSB)"'
          ' <ridthauddin_arahim@example.com>'): ['Ridthauddin', 'Rahim'],
-        ('"Boland, Patrick \(Global Xxx Group, Ireland \)"'
+        ('"Boland, Patrick (Global Xxx Group, Ireland )"'
          ' <Patrick.Boland@example.com>'): ['Boland', 'Patrick'],
-        '"Mates Rate \(Wine\)" <amen@example.com.com>':
+        '"Mates Rate (Wine)" <amen@example.com.com>':
         ['Mates', 'Rate', 'Wine'],
-        ('"Morgan, Paul \(Business Xxx RI, Xxx Xxx Group\)"'
+        ('"Morgan, Paul (Business Xxx RI, Xxx Xxx Group)"'
          ' <paul.morgan@example.com>'): ['Morgan', 'Paul'],
-        '"David DECOSTER \(Domicile\)" <decosterdavid@xxx.be>':
+        '"David DECOSTER (Domicile)" <decosterdavid@xxx.be>':
         ['David', 'DECOSTER', 'Domicile']
         }
 
@@ -155,7 +155,7 @@ def test_extract_names():
         extracted_names = h.extract_names(sender)
         # check that extracted names could be compiled
         try:
-            re.compile("|".join(extracted_names))
+            re.compile(r"|".join(map(re.escape, extracted_names)))
         except Exception as e:
             ok_(False, ("Failed to compile extracted names {}"
                         "\n\nReason: {}").format(extracted_names, e))


### PR DESCRIPTION
Resolves many warnings like `talon/quotations.py:24: DeprecationWarning: invalid escape sequence \s` when running with warnings enabled.

- Fixes #244.