### PR TITLE
Fix gmail quote

### DIFF
--- a/talon/html_quotations.py
+++ b/talon/html_quotations.py
@@ -6,7 +6,7 @@ messages (without quoted messages) from html
 from __future__ import absolute_import
 import regex as re
 
-from talon.utils import cssselect 
+from talon.utils import cssselect
 
 CHECKPOINT_PREFIX = '#!%!'
 CHECKPOINT_SUFFIX = '!%!#'
@@ -15,6 +15,10 @@ CHECKPOINT_PATTERN = re.compile(CHECKPOINT_PREFIX + '\d+' + CHECKPOINT_SUFFIX)
 # HTML quote indicators (tag ids)
 QUOTE_IDS = ['OLK_SRC_BODY_SECTION']
 RE_FWD = re.compile("^[-]+[ ]*Forwarded message[ ]*[-]+$", re.I | re.M)
+# Leading "On ... wrote:" header inside a Gmail quote (classic compose).
+RE_GMAIL_QUOTE_HEADER = re.compile(r"On\s.{0,500}wrote\s*:", re.I | re.S)
+# Leftover greeting/name after removing a gmail_quote that actually wraps the body.
+GMAIL_QUOTE_STUB_MAX_CHARS = 40
 
 
 def add_checkpoint(html_note, counter):
@@ -77,12 +81,64 @@ def delete_quotation_tags(html_note, counter, quotation_checkpoints):
         return counter, tag_in_quotation
 
 
-def cut_gmail_quote(html_message):
-    ''' Cuts the outermost block element with class gmail_quote. '''
-    gmail_quote = cssselect('div.gmail_quote', html_message)
-    if gmail_quote and (gmail_quote[0].text is None or not RE_FWD.match(gmail_quote[0].text)):
-        gmail_quote[0].getparent().remove(gmail_quote[0])
+def _tree_text(element):
+    """Return concatenated descendant text without mutating the tree."""
+    return (element.xpath('string()') or '').strip()
+
+
+def _gmail_quote_looks_like_quotation(quote):
+    """True if the node looks like quoted history rather than the current body."""
+    if cssselect('.gmail_attr', quote) or cssselect('blockquote.gmail_quote', quote):
         return True
+    return bool(RE_GMAIL_QUOTE_HEADER.search(_tree_text(quote)))
+
+
+def _should_preserve_gmail_quote(remaining_text, original_text, looks_like_quotation):
+    """True if cutting the gmail_quote would leave almost no readable text.
+
+    Mirrors cut_from_block's parent_div_is_all_content / _readable_text_empty:
+    do not strip when the quote wrapper holds the message. Completely empty
+    leftover is always preserved. A short leftover (greeting) is preserved
+    only when the node does not look like a real Gmail quote, so short replies
+    to quoted threads are still stripped.
+    """
+    if not remaining_text:
+        return True
+    if looks_like_quotation or not original_text:
+        return False
+    return (
+        len(remaining_text) <= GMAIL_QUOTE_STUB_MAX_CHARS
+        and len(remaining_text) < 0.05 * len(original_text)
+    )
+
+
+def cut_gmail_quote(html_message):
+    ''' Cuts the outermost block element with class gmail_quote.
+
+    Does not cut if that would leave the message with almost no readable text.
+    '''
+    gmail_quote = cssselect('div.gmail_quote', html_message)
+    if not gmail_quote:
+        return False
+    quote = gmail_quote[0]
+    if quote.text is not None and RE_FWD.match(quote.text):
+        return False
+
+    parent = quote.getparent()
+    if parent is None:
+        return False
+
+    original_text = _tree_text(html_message)
+    looks_like_quotation = _gmail_quote_looks_like_quotation(quote)
+    idx = parent.index(quote)
+    parent.remove(quote)
+    remaining_text = _tree_text(html_message)
+
+    if _should_preserve_gmail_quote(
+            remaining_text, original_text, looks_like_quotation):
+        parent.insert(idx, quote)
+        return False
+    return True
 
 
 def cut_microsoft_quote(html_message):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 coverage
 mock
 nose>=1.2.1
+pynose>=1.5.5

--- a/tests/html_quotations_test.py
+++ b/tests/html_quotations_test.py
@@ -148,6 +148,60 @@ def test_gmail_quote_compact():
         RE_WHITESPACE.sub('', quotations.extract_from_html(msg_body)))
 
 
+def test_gmail_quote_wrapping_body_keeps_content():
+    """Gmail nested quote wrappers around the body must not strip the message.
+
+    Gmail sometimes wraps the current compose (often a signature template)
+    in div.gmail_quote / gmail_quote_container with only a greeting outside.
+    Cutting that node would leave almost no readable text.
+    """
+    msg_body = (
+        '<div dir="ltr">'
+        '<div><span style="background-color:transparent">Heather,</span></div>'
+        '<div class="gmail_quote gmail_quote_container">'
+        '<div dir="ltr"><div class="gmail_quote">'
+        '<div dir="ltr" class="gmail_signature" data-smartmail="gmail_signature">'
+        '<div>Thank you for applying to our Production Associate opportunity '
+        'here at Waites Sensor Technologies! I reviewed your resume and would '
+        'love to schedule some time to learn more about your background.</div>'
+        '<div>What is your availability for a phone call next week?</div>'
+        '</div></div></div></div></div>'
+    )
+    extracted = quotations.extract_from_html(msg_body)
+    ok_('Thank you for applying' in extracted)
+    ok_('availability for a phone call' in extracted)
+    ok_('Heather,' in extracted)
+
+
+def test_gmail_quote_entire_body_is_kept():
+    """A gmail_quote that wraps the whole message is not cut."""
+    msg_body = (
+        '<div class="gmail_quote">'
+        '<div>Thank you for applying to our Production Associate opportunity.</div>'
+        '</div>'
+    )
+    extracted = quotations.extract_from_html(msg_body)
+    ok_('Thank you for applying' in extracted)
+
+
+def test_gmail_quote_short_reply_to_long_quote():
+    """A short reply to a real Gmail quote is still stripped."""
+    quoted = 'Quoted paragraph from the previous message. ' * 20
+    msg_body = (
+        'OK'
+        '<div class="gmail_quote">'
+        '<div class="gmail_attr">On Mon, Apr 2, 2012 at 6:26 PM, Bob wrote:</div>'
+        '<blockquote class="gmail_quote">'
+        '<div>' + quoted + '</div>'
+        '</blockquote>'
+        '</div>'
+    )
+    extracted = quotations.extract_from_html(msg_body)
+    eq_("<html><head></head><body>OK</body></html>",
+        RE_WHITESPACE.sub('', extracted))
+    ok_('Quoted paragraph' not in extracted)
+
+
 def test_gmail_quote_blockquote():
     msg_body = """Message
 <blockquote class="gmail_quote">


### PR DESCRIPTION
# Talon stripped-html: Gmail quote wrapper false positive

Date: 2026-08-29
Sample: `body-html.html` → `stripped.html`
Library: `talon` (`quotations.extract_from_html`)

## Symptom

Talon reduced a 3395-character Gmail HTML body to 130 characters. Almost the entire recruiting email disappeared.

**Input leftover after strip:** only the greeting `Heather,`

```html
<html><head></head><body><div dir="ltr"><div><span style="background-color:transparent">Heather,</span></div></div>
</body></html>
```

**Missing content:** the full message (“Thank you for applying…”), job-description link, and John Dow signature (logo, title, email, phone).

## Root cause

`extract_from_html_tree` always tries Gmail quote cutting first:

```python
cut_quotations = (html_quotations.cut_gmail_quote(html_tree) or
                  html_quotations.cut_zimbra_quote(html_tree) or
                  ...)
```

`cut_gmail_quote` selected every `div.gmail_quote` and **deleted the first match as a whole subtree**, with no check for `gmail_attr`, “On … wrote:”, an inner `blockquote`, or whether anything readable would remain.

The first match in this sample was:

```html
<div class="gmail_quote gmail_quote_container">
```

That node wrapped the real body. Direct `.text` was `None`, so the forwarded-message exception (`----- Forwarded message -----`) did not apply. The subtree was removed.

The later checkpoint / plain-text quotation pass was not involved. If `cut_gmail_quote` was skipped, every line was marked `t` or `e` and nothing else would have been stripped.

## HTML structure

This is not a classic Gmail quoted reply. Classic Gmail looks like:

```html
<div class="gmail_quote">
  On Mon, Apr 2, … wrote:<br>
  <blockquote class="gmail_quote">…previous message…</blockquote>
</div>
```

The sample was:

```html
<div dir="ltr">
  <div><span>Heather,</span></div>                    <!-- only sibling kept -->
  <div class="gmail_quote gmail_quote_container">    <!-- first match, deleted whole -->
    <!-- 6 more nested div.gmail_quote -->
      <div class="gmail_signature" data-smartmail="gmail_signature">
        Thank you for applying…                      <!-- actual body -->
        …John Doe / phone / logo…
      </div>
  </div>
</div>
```

There is no `gmail_attr`, no “On … wrote:”, no `blockquote`. Seven nested `gmail_quote` nodes all contained the same body text. Gmail also labeled the body as a signature (`gmail_signature` / `data-smartmail`).

Typical compose pattern: greeting typed in the editor, template/body sitting in the signature, then Gmail wrapping that block in `gmail_quote` / `gmail_quote_container` from reply nesting. Talon still treated the wrapper as quoted history.

## Measured leftover vs full text

Using `xpath('string()')` on the parsed tree:

| Sample | Full chars | Remaining after cut | Remaining / full | Looks like a real quote |
|---|---:|---:|---:|---|
| This message (`body-html.html`) | 646 | 8 (`Heather,`) | 1.2% | No |
| Unit test `test_gmail_quote` (`Reply` + short quote) | 86 | 5 (`Reply`) | 5.8% | Yes (`On … wrote:`) |
| Compact Gmail quote unit test | 65 | 5 (`Reply`) | 7.7% | Yes |
| Fixture `tests/fixtures/html_replies/gmail.html` | 128 | 25 | 19.5% | Yes (`On … wrote:` + `blockquote`) |

`_readable_text_empty` in `extract_from_html_tree` already restores the original body when leftover is **completely** empty. It did not help here because `Heather,` is not empty.

A leftover-length check alone cannot distinguish `Reply` from `Heather,`. A ratio-only check would also break production short replies (`OK` + long quoted thread). Real Gmail quotes must still be stripped.

## Why existing tests encoded the old behavior

`test_gmail_quote` and `test_gmail_quote_compact` expect anything inside `div.gmail_quote` to be removed, leaving only the sibling reply. That is correct for real quotes. This sample had almost no sibling reply, so the output collapsed to `Heather,`.

The only previous escape hatch was a forwarded-message header as **direct text** of the quote node. Nested headers do not count.

## Fix (implemented)

Do not cut if removing the node would leave almost no readable text (same idea as `cut_from_block`’s `parent_div_is_all_content` and `_readable_text_empty`).

In `talon/html_quotations.py` `cut_gmail_quote`:

1. Tentatively remove the outermost `div.gmail_quote`.
2. If leftover readable text is **empty** → restore the node (the quote *is* the message).
3. If leftover is only a **stub** (≤ 40 characters and &lt; 5% of the message) **and** the node is not a real Gmail quote → restore.
4. Real quotes are still stripped: `.gmail_attr`, `blockquote.gmail_quote`, or `On … wrote:` in the quote text. Short replies such as `OK` to a long quoted thread still lose the quote.

After the fix, `extract_from_html(body-html.html)` returns the original 3395-character HTML, including the recruiting copy, link, and signature.

## Secondary issue (not what stripped this file)

HTML quotation stripping does not remove `gmail_signature`. If the plain-text signature extractor is run later, the body could be dropped again because Gmail labeled the whole pitch as a signature.

## Tests added

- `test_gmail_quote_wrapping_body_keeps_content` — greeting + nested `gmail_quote_container` / `gmail_signature` wrapping the body
- `test_gmail_quote_entire_body_is_kept` — `gmail_quote` is the whole message
- `test_gmail_quote_short_reply_to_long_quote` — short `OK` + `gmail_attr` + `blockquote.gmail_quote` still stripped
