### PR TITLE
Support Ukrainian reply headers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,9 @@ talon
 
 Mailgun library to extract message quotations and signatures.
 
+Plain-text quotation headers are recognized in several languages, including
+Ukrainian reply headers produced by localized mail clients.
+
 If you ever tried to parse message quotations or signatures you know that absence of any formatting standards in this area could make this task a nightmare. Hopefully this library will make your life much easier. The name of the project is inspired by TALON - multipurpose robot designed to perform missions ranging from reconnaissance to combat and operate in a number of hostile environments. That’s what a good quotations and signature parser should be like :smile:
 
 Usage

--- a/talon/quotations.py
+++ b/talon/quotations.py
@@ -167,6 +167,14 @@ RE_ANDROID_WROTE = re.compile(r'[\s]*[-]+.*({})[ ]*[-]+'.format(
 # > wrote:
 RE_POLYMAIL = re.compile(r'On.*\s{2}<\smailto:.*\s> wrote:', re.I)
 
+# 23 лист. 2015 р. 09:18 "John Smith" <john@example.com> пише:
+RE_UKRAINIAN_WROTE = re.compile(
+    r'^[> ]*(?:[^\W\d_]{2,4},[ ]+)?\d{1,2}[ ]+[^\W\d_]+\.?[ ]+'
+    r'\d{4}[ ]+р\.[ ]+(?:о[ ]+)?\d{1,2}:\d{2}(?:[ ]+\S+)?[ ]+'
+    r'.+<[^<>\s]+@[^<>\s]+>[ ]+пише:[ ]*$',
+    re.I | re.M,
+)
+
 SPLITTER_PATTERNS = [
     RE_ORIGINAL_MESSAGE,
     RE_ON_DATE_SMB_WROTE,
@@ -184,7 +192,8 @@ SPLITTER_PATTERNS = [
     # Sent from Samsung MobileName <address@example.com> wrote:
     re.compile(r'Sent from Samsung.* \S+@\S+> wrote'),
     RE_ANDROID_WROTE,
-    RE_POLYMAIL
+    RE_POLYMAIL,
+    RE_UKRAINIAN_WROTE,
     ]
 
 RE_LINK = re.compile(r'<(http://[^>]*)>')

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -35,6 +35,22 @@ On 11-Apr-2011, at 6:54 PM, Roman Tkachenko <romant@example.com> wrote:
 
     assert "Test reply" == quotations.extract_from_plain(msg_body)
 
+
+def test_pattern_ukrainian_date_somebody_wrote():
+    msg_body = """Reply
+23 лист. 2015 р. 09:18 "John Smith" <john@example.com> пише:
+
+> Original message"""
+
+    assert "Reply" == quotations.extract_from_plain(msg_body)
+
+
+def test_ukrainian_wrote_word_without_reply_header_is_preserved():
+    msg_body = "Автор пише: це звичайне речення без заголовка відповіді."
+
+    assert msg_body == quotations.extract_from_plain(msg_body)
+
+
 def test_pattern_on_date_polymail():
     msg_body = """Test reply
 


### PR DESCRIPTION
Recognize localized Ukrainian reply headers while requiring their full date, sender, email, and `пише:` structure to avoid matching ordinary prose.

Closes #69.

Validation: 55 focused quotation tests pass. The full suite reaches 143 passes; its five Yahoo-test `NameError` failures reproduce unchanged on current `master` after #240.
